### PR TITLE
Update Docs - OrderBook v1.1 Sample Result

### DIFF
--- a/_data/api-spec-v1-1.json
+++ b/_data/api-spec-v1-1.json
@@ -299,7 +299,7 @@
                                 "result": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/definitions/MarketSummary"
+                                        "$ref": "#/definitions/OrderBook"
                                     }
                                 }
                             }

--- a/api/v1-1/assets/index.html
+++ b/api/v1-1/assets/index.html
@@ -734,20 +734,18 @@
   <span class="hljs-attr">&quot;message&quot;</span>: <span class="hljs-string">&quot;&apos;&apos;&quot;</span>,
   <span class="hljs-attr">&quot;result&quot;</span>: [
     {
-      <span class="hljs-attr">&quot;MarketName&quot;</span>: <span class="hljs-string">&quot;BTC-LTC&quot;</span>,
-      <span class="hljs-attr">&quot;High&quot;</span>: <span class="hljs-number">0.0135</span>,
-      <span class="hljs-attr">&quot;Low&quot;</span>: <span class="hljs-number">0.012</span>,
-      <span class="hljs-attr">&quot;Volume&quot;</span>: <span class="hljs-number">3833.97619253</span>,
-      <span class="hljs-attr">&quot;Last&quot;</span>: <span class="hljs-number">0.01349998</span>,
-      <span class="hljs-attr">&quot;BaseVolume&quot;</span>: <span class="hljs-number">47.03987026</span>,
-      <span class="hljs-attr">&quot;TimeStamp&quot;</span>: <span class="hljs-string">&quot;2014-07-09T07:22:16.72&quot;</span>,
-      <span class="hljs-attr">&quot;Bid&quot;</span>: <span class="hljs-number">0.01271001</span>,
-      <span class="hljs-attr">&quot;Ask&quot;</span>: <span class="hljs-number">0.012911</span>,
-      <span class="hljs-attr">&quot;OpenBuyOrders&quot;</span>: <span class="hljs-number">45</span>,
-      <span class="hljs-attr">&quot;OpenSellOrders&quot;</span>: <span class="hljs-number">45</span>,
-      <span class="hljs-attr">&quot;PrevDay&quot;</span>: <span class="hljs-number">0.01229501</span>,
-      <span class="hljs-attr">&quot;Created&quot;</span>: <span class="hljs-string">&quot;2014-02-13T00:00:00&quot;</span>,
-      <span class="hljs-attr">&quot;DisplayMarketName&quot;</span>: <span class="hljs-string">&quot;string&quot;</span>
+      <span class="hljs-attr">&quot;buy&quot;</span>: [
+        {
+          <span class="hljs-attr">&quot;quantity&quot;</span>: <span class="hljs-number">12.37</span>,
+          <span class="hljs-attr">&quot;rate&quot;</span>: <span class="hljs-number">32.55412402</span>
+        }
+      ],
+      <span class="hljs-attr">&quot;sell&quot;</span>: [
+        {
+          <span class="hljs-attr">&quot;quantity&quot;</span>: <span class="hljs-number">12.37</span>,
+          <span class="hljs-attr">&quot;rate&quot;</span>: <span class="hljs-number">32.55412402</span>
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This docs formaly showed the sample result for MarketSummary
<img width="1192" alt="screen shot 2018-11-20 at 6 18 03 pm" src="https://user-images.githubusercontent.com/17007838/48791068-21043f00-ecf1-11e8-9377-c51da0ba4b33.png">

This PR uses the appropriate sample result
<img width="1190" alt="screen shot 2018-11-20 at 6 18 29 pm" src="https://user-images.githubusercontent.com/17007838/48791067-206ba880-ecf1-11e8-8211-177604beb73d.png">

